### PR TITLE
Revert "Bump software.amazon.awscdk:aws-cdk-lib from 2.106.0 to 2.106.1 in /assets/FamilyDirectoryUpdateMemberLambda"

### DIFF
--- a/assets/FamilyDirectoryUpdateMemberLambda/pom.xml
+++ b/assets/FamilyDirectoryUpdateMemberLambda/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>2.106.1</version>
+            <version>2.106.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reverts Kapral67/FamilyDirectory#419