### PR TITLE
Revert "Bump software.amazon.awscdk:aws-cdk-lib from 2.106.0 to 2.106.1 in /assets/familydirectory-service-assets"

### DIFF
--- a/assets/familydirectory-service-assets/build.gradle
+++ b/assets/familydirectory-service-assets/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'org.apache.commons:commons-text:1.11.0'
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
-    implementation 'software.amazon.awscdk:aws-cdk-lib:2.106.1'
+    implementation 'software.amazon.awscdk:aws-cdk-lib:2.106.0'
     implementation 'software.amazon.awscdk:apigatewayv2-integrations-alpha:2.106.0-alpha.0'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.3'


### PR DESCRIPTION
Reverts Kapral67/FamilyDirectory#416